### PR TITLE
Use transport factory in Writer\Mail constructor

### DIFF
--- a/src/Writer/Mail.php
+++ b/src/Writer/Mail.php
@@ -93,7 +93,6 @@ class Mail extends AbstractWriter
             if (is_array($transport)) {
                 $transport = Transport\Factory::create($transport);
             }
-
         }
 
         // Ensure we have a valid mail message

--- a/src/Writer/Mail.php
+++ b/src/Writer/Mail.php
@@ -90,6 +90,10 @@ class Mail extends AbstractWriter
             if (is_array($mail)) {
                 $mail = MailMessageFactory::getInstance($mail);
             }
+            if (is_array($transport)) {
+                $transport = Transport\Factory::create($transport);
+            }
+
         }
 
         // Ensure we have a valid mail message

--- a/test/Writer/MailTest.php
+++ b/test/Writer/MailTest.php
@@ -122,10 +122,25 @@ class MailTest extends \PHPUnit_Framework_TestCase
             'body'      => 'body',
         ];
 
+        $transportOptions = [
+            'type' => 'smtp',
+            'options' => [
+                'host' => 'test',
+                'connection_class' => 'login',
+                'connection_config' => [
+                    'username' => 'foo',
+                    'smtp_password' => 'bar',
+                    'ssl' => 'tls'
+                ]
+            ]
+        ];
+
         $writer = new MailWriter([
             'mail' => $messageOptions,
+            'transport' => $transportOptions
         ]);
 
         $this->assertAttributeInstanceOf('Zend\Mail\Message', 'mail', $writer);
+        $this->assertAttributeInstanceOf('Zend\Mail\Transport\Smtp', 'transport', $writer);
     }
 }

--- a/test/Writer/MailTest.php
+++ b/test/Writer/MailTest.php
@@ -122,10 +122,27 @@ class MailTest extends \PHPUnit_Framework_TestCase
             'body'      => 'body',
         ];
 
+        $writer = new MailWriter([
+            'mail' => $messageOptions,
+        ]);
+
+        $this->assertAttributeInstanceOf('Zend\Mail\Message', 'mail', $writer);
+    }
+
+    public function testConstructWithMailTransportAsArrayOptions()
+    {
+        $messageOptions = [
+            'encoding'  => 'UTF-8',
+            'from'      => 'matthew@example.com',
+            'to'        => 'zf-devteam@example.com',
+            'subject'   => 'subject',
+            'body'      => 'body',
+        ];
+
         $transportOptions = [
             'type' => 'smtp',
             'options' => [
-                'host' => 'test',
+                'host' => 'test.dev',
                 'connection_class' => 'login',
                 'connection_config' => [
                     'username' => 'foo',
@@ -137,10 +154,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
         $writer = new MailWriter([
             'mail' => $messageOptions,
-            'transport' => $transportOptions
+            'transport' => $transportOptions,
         ]);
 
-        $this->assertAttributeInstanceOf('Zend\Mail\Message', 'mail', $writer);
         $this->assertAttributeInstanceOf('Zend\Mail\Transport\Smtp', 'transport', $writer);
     }
 }


### PR DESCRIPTION
The transport factory allows to config  the transport via array options.
