### PR TITLE
Updated component to work with zend-servicemanager v2 & v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,21 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: hhvm 
     - php: hhvm 
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION='^2.7.5'
   allow_failures:
     - php: hhvm
 
@@ -45,8 +45,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-db zendframework/zend-mail zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,24 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_V2=true
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -34,6 +45,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
-        "zendframework/zend-stdlib": "^2.7",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "zendframework/zend-console": "^2.5",
+        "zendframework/zend-console": "^2.6",
         "zendframework/zend-db": "^2.5",
         "zendframework/zend-escaper": "^2.5",
         "zendframework/zend-filter": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,18 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
-        "zendframework/zend-stdlib": "~2.7",
-        "psr/log": "~1.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7",
+        "psr/log": "^1.0"
     },
     "require-dev": {
-        "zendframework/zend-console": "~2.5",
-        "zendframework/zend-db": "~2.5",
-        "zendframework/zend-escaper": "~2.5",
-        "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-mail": "~2.5",
-        "zendframework/zend-mvc": "~2.5",
-        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-console": "^2.5",
+        "zendframework/zend-db": "^2.5",
+        "zendframework/zend-escaper": "^2.5",
+        "zendframework/zend-filter": "^2.5",
+        "zendframework/zend-mail": "^2.5",
+        "zendframework/zend-validator": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
@@ -43,7 +42,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev",
-            "dev-develop": "3.0-dev"
+            "dev-develop": "2.7-dev"
         }
     },
     "autoload-dev": {

--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -30,6 +30,14 @@ class FilterPluginManager extends AbstractPluginManager
         Filter\Regex::class          => InvokableFactory::class,
         Filter\SuppressFilter::class => InvokableFactory::class,
         Filter\Validator::class      => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendlogfiltermock'           => InvokableFactory::class,
+        'zendlogfilterpriority'       => InvokableFactory::class,
+        'zendlogfilterregex'          => InvokableFactory::class,
+        'zendlogfiltersuppressfilter' => InvokableFactory::class,
+        'zendlogfiltervalidator'      => InvokableFactory::class,
     ];
 
     protected $instanceOf = Filter\FilterInterface::class;
@@ -59,11 +67,19 @@ class FilterPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
+     * @param mixed $plugin
      * @throws InvalidServiceException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must implement %s\Filter\FilterInterface',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__
+            ));
+        }
     }
 }

--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 class FilterPluginManager extends AbstractPluginManager
@@ -32,4 +33,37 @@ class FilterPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Filter\FilterInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/FormatterPluginManager.php
+++ b/src/FormatterPluginManager.php
@@ -31,6 +31,15 @@ class FormatterPluginManager extends AbstractPluginManager
         Formatter\Db::class               => InvokableFactory::class,
         Formatter\ErrorHandler::class     => InvokableFactory::class,
         Formatter\ExceptionHandler::class => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendlogformatterbase'             => InvokableFactory::class,
+        'zendlogformattersimple'           => InvokableFactory::class,
+        'zendlogformatterxml'              => InvokableFactory::class,
+        'zendlogformatterdb'               => InvokableFactory::class,
+        'zendlogformattererrorhandler'     => InvokableFactory::class,
+        'zendlogformatterexceptionhandler' => InvokableFactory::class,
     ];
 
     protected $instanceOf = Formatter\FormatterInterface::class;
@@ -60,11 +69,19 @@ class FormatterPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
-     * @throws InvalidServiceException
+     * @param mixed $plugin
+     * @throws Exception\InvalidArgumentException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must implement %s\Formatter\FormatterInterface',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__
+            ));
+        }
     }
 }

--- a/src/FormatterPluginManager.php
+++ b/src/FormatterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 class FormatterPluginManager extends AbstractPluginManager
@@ -33,4 +34,37 @@ class FormatterPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Formatter\FormatterInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/LoggerAbstractServiceFactory.php
+++ b/src/LoggerAbstractServiceFactory.php
@@ -10,8 +10,9 @@
 namespace Zend\Log;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Logger abstract service factory.
@@ -33,9 +34,9 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
     protected $configKey = 'log';
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         $config = $this->getConfig($container);
         if (empty($config)) {
@@ -43,6 +44,14 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         return isset($config[$requestedName]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        return $this->canCreate($container, $requestedName);
     }
 
     /**
@@ -59,6 +68,14 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        return $this($container, $requestedName);
+    }
+
+    /**
      * Retrieve configuration for loggers, if any
      *
      * @param ContainerInterface $services
@@ -71,13 +88,13 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
             return $this->config;
         }
 
-        if (!$services->has('Config')) {
+        if (!$services->has('config')) {
             $this->config = [];
 
             return $this->config;
         }
 
-        $config = $services->get('Config');
+        $config = $services->get('config');
         if (!isset($config[$this->configKey])) {
             $this->config = [];
 
@@ -89,6 +106,12 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
         return $this->config;
     }
 
+    /**
+     * Process and return the configuration from the container.
+     *
+     * @param array $config Passed by reference
+     * @param ContainerInterface $services
+     */
     protected function processConfig(&$config, ContainerInterface $services)
     {
         if (isset($config['writer_plugin_manager'])

--- a/src/LoggerServiceFactory.php
+++ b/src/LoggerServiceFactory.php
@@ -9,20 +9,41 @@
 
 namespace Zend\Log;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * Logger.
+ * Factory for logger instances.
  */
 class LoggerServiceFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Factory for zend-servicemanager v3.
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param null|array $options
+     * @return Logger
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         // Configure the logger
-        $config = $serviceLocator->get('Config');
+        $config = $container->get('config');
         $logConfig = isset($config['log']) ? $config['log'] : [];
-        $logger = new Logger($logConfig);
-        return $logger;
+        return new Logger($logConfig);
+    }
+
+    /**
+     * Factory for zend-servicemanager v2.
+     *
+     * Proxies to `__invoke()`.
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return Logger
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, Logger::class);
     }
 }

--- a/src/ProcessorPluginManager.php
+++ b/src/ProcessorPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -32,4 +33,37 @@ class ProcessorPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Processor\ProcessorInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/Writer/FingersCrossed.php
+++ b/src/Writer/FingersCrossed.php
@@ -9,14 +9,14 @@
 namespace Zend\Log\Writer;
 
 use Traversable;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Stdlib\ArrayUtils;
 use Zend\Log\Exception;
 use Zend\Log\Filter\FilterInterface;
 use Zend\Log\Filter\Priority as PriorityFilter;
 use Zend\Log\Formatter\FormatterInterface;
 use Zend\Log\Logger;
 use Zend\Log\WriterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * Buffers all events until the strategy determines to flush them.

--- a/src/WriterPluginManager.php
+++ b/src/WriterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -49,4 +50,37 @@ class WriterPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Writer\WriterInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/WriterPluginManager.php
+++ b/src/WriterPluginManager.php
@@ -19,9 +19,6 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 class WriterPluginManager extends AbstractPluginManager
 {
     protected $aliases = [
-        'null'             => 'noop',
-        Writer\Null::class => 'noop',
-
         'chromephp'      => Writer\ChromePhp::class,
         'db'             => Writer\Db::class,
         'fingerscrossed' => Writer\FingersCrossed::class,
@@ -33,6 +30,13 @@ class WriterPluginManager extends AbstractPluginManager
         'stream'         => Writer\Stream::class,
         'syslog'         => Writer\Syslog::class,
         'zendmonitor'    => Writer\ZendMonitor::class,
+
+        // The following are for backwards compatibility only; users
+        // should update their code to use the noop writer instead.
+        'null'              => Writer\Noop::class,
+        Writer\Null::class  => Writer\Noop::class,
+        'zendlogwriternull' => Writer\Noop::class,
+
     ];
 
     protected $factories = [
@@ -47,6 +51,20 @@ class WriterPluginManager extends AbstractPluginManager
         Writer\Syslog::class         => InvokableFactory::class,
         Writer\FingersCrossed::class => InvokableFactory::class,
         Writer\ZendMonitor::class    => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendlogwriterchromephp'      => InvokableFactory::class,
+        'zendlogwriterdb'             => InvokableFactory::class,
+        'zendlogwriterfirephp'        => InvokableFactory::class,
+        'zendlogwritermail'           => InvokableFactory::class,
+        'zendlogwritermock'           => InvokableFactory::class,
+        'zendlogwriternoop'           => InvokableFactory::class,
+        'zendlogwriterpsr'            => InvokableFactory::class,
+        'zendlogwriterstream'         => InvokableFactory::class,
+        'zendlogwritersyslog'         => InvokableFactory::class,
+        'zendlogwriterfingerscrossed' => InvokableFactory::class,
+        'zendlogwriterzendmonitor'    => InvokableFactory::class,
     ];
 
     protected $instanceOf = Writer\WriterInterface::class;
@@ -76,11 +94,19 @@ class WriterPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
+     * @param mixed $plugin
      * @throws InvalidServiceException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must implement %s\Writer\WriterInterface',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__
+            ));
+        }
     }
 }

--- a/test/Filter/ValidatorTest.php
+++ b/test/Filter/ValidatorTest.php
@@ -19,6 +19,16 @@ use Zend\Validator\NotEmpty as NotEmptyFilter;
  */
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (! class_exists(ValidatorChain::class)) {
+            $this->markTestSkipped(
+                'zend-validator related tests are disabled when testing zend-servicemanager v3 '
+                . 'forwards compatibility, until zend-validator is also forwards compatible'
+            );
+        }
+    }
+
     public function testValidatorFilter()
     {
         $filter = new Validator(new DigitsFilter());

--- a/test/FilterPluginManagerCompatibilityTest.php
+++ b/test/FilterPluginManagerCompatibilityTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Log\Exception\InvalidArgumentException;
+use Zend\Log\Filter;
+use Zend\Log\FilterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class FilterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new FilterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Filter\FilterInterface::class;
+    }
+
+    /**
+     * Overrides CommonPluginManagerTrait::aliasProvider
+     *
+     * Iterates through aliases, and for adapters that require extensions,
+     * tests if the extension is loaded, skipping that alias if not.
+     *
+     * @return \Traversable
+     */
+    public function aliasProvider()
+    {
+        $pluginManager = $this->getPluginManager();
+        $r = new ReflectionProperty($pluginManager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($pluginManager);
+
+        foreach ($aliases as $alias => $target) {
+            switch ($target) {
+                case Filter\Priority::class:
+                    // intentionally fall through
+                case Filter\Regex::class:
+                    // intentionally fall through
+                case Filter\Timestamp::class:
+                    // intentionally fall through
+                case Filter\Validator::class:
+                    // Skip, as these each have required arguments
+                    break;
+                default:
+                    yield $alias => [$alias, $target];
+            }
+        }
+    }
+}

--- a/test/FormatterPluginManagerCompatibilityTest.php
+++ b/test/FormatterPluginManagerCompatibilityTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Log;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionProperty;
 use Zend\Log\Exception\InvalidArgumentException;
 use Zend\Log\Formatter;
 use Zend\Log\FormatterPluginManager;

--- a/test/FormatterPluginManagerCompatibilityTest.php
+++ b/test/FormatterPluginManagerCompatibilityTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Log\Exception\InvalidArgumentException;
+use Zend\Log\Formatter;
+use Zend\Log\FormatterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class FormatterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new FormatterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Formatter\FormatterInterface::class;
+    }
+}

--- a/test/LoggerAbstractServiceFactoryTest.php
+++ b/test/LoggerAbstractServiceFactoryTest.php
@@ -99,6 +99,13 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testRetrievesDatabaseServiceFromServiceManagerWhenEncounteringDbWriter()
     {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'zend-db related tests are disabled when testing zend-servicemanager v3 '
+                . 'forwards compatibility, until zend-db is also forwards compatible'
+            );
+        }
+
         $db = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
             ->disableOriginalConstructor()
             ->getMock();

--- a/test/LoggerAbstractServiceFactoryTest.php
+++ b/test/LoggerAbstractServiceFactoryTest.php
@@ -14,6 +14,7 @@ use Zend\Log\ProcessorPluginManager;
 use Zend\Log\Writer\Noop;
 use Zend\Log\WriterPluginManager;
 use Zend\Log\Writer\Db as DbWriter;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceManager;
 
@@ -34,13 +35,19 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->serviceManager = new ServiceManager(['abstract_factories' => [LoggerAbstractServiceFactory::class]]);
-        $this->serviceManager->setService('Config', [
-            'log' => [
-                'Application\Frontend' => [],
-                'Application\Backend'  => [],
+        $this->serviceManager = new ServiceManager();
+        $config = new Config([
+            'abstract_factories' => [LoggerAbstractServiceFactory::class],
+            'services' => [
+                'config' => [
+                    'log' => [
+                        'Application\Frontend' => [],
+                        'Application\Backend'  => [],
+                    ],
+                ],
             ],
         ]);
+        $config->configureServiceManager($this->serviceManager);
     }
 
     /**
@@ -96,26 +103,32 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $serviceManager = new ServiceManager(['abstract_factories' => [LoggerAbstractServiceFactory::class]]);
-        $serviceManager->setService('Db\Logger', $db);
-        $serviceManager->setService('Config', [
-            'log' => [
-                'Application\Log' => [
-                    'writers' => [
-                        [
-                            'name'     => 'db',
-                            'priority' => 1,
-                            'options'  => [
-                                'separator' => '_',
-                                'column'    => [],
-                                'table'     => 'applicationlog',
-                                'db'        => 'Db\Logger',
+        $config = new Config([
+            'abstract_factories' => [LoggerAbstractServiceFactory::class],
+            'services' => [
+                'Db\Logger' => $db,
+                'config' => [
+                    'log' => [
+                        'Application\Log' => [
+                            'writers' => [
+                                [
+                                    'name'     => 'db',
+                                    'priority' => 1,
+                                    'options'  => [
+                                        'separator' => '_',
+                                        'column'    => [],
+                                        'table'     => 'applicationlog',
+                                        'db'        => 'Db\Logger',
+                                    ],
+                                ],
                             ],
                         ],
                     ],
                 ],
             ],
         ]);
+        $serviceManager = new ServiceManager();
+        $config->configureServiceManager($serviceManager);
 
         $logger = $serviceManager->get('Application\Log');
         $this->assertInstanceOf('Zend\Log\Logger', $logger);
@@ -142,15 +155,21 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $mockWriter = $this->getMock('Zend\Log\Writer\WriterInterface');
         $writers->setService('CustomWriter', $mockWriter);
 
-        $services = new ServiceManager(['abstract_factories' => [LoggerAbstractServiceFactory::class]]);
-        $services->setService('LogWriterManager', $writers);
-        $services->setService('Config', [
-            'log' => [
-                'Application\Frontend' => [
-                    'writers' => [['name' => 'CustomWriter']],
+        $config = new Config([
+            'abstract_factories' => [LoggerAbstractServiceFactory::class],
+            'services' => [
+                'LogWriterManager' => $writers,
+                'config' => [
+                    'log' => [
+                        'Application\Frontend' => [
+                            'writers' => [['name' => 'CustomWriter']],
+                        ],
+                    ],
                 ],
             ],
         ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
 
         $log = $services->get('Application\Frontend');
         $logWriters = $log->getWriters();
@@ -168,16 +187,22 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $mockProcessor = $this->getMock('Zend\Log\Processor\ProcessorInterface');
         $processors->setService('CustomProcessor', $mockProcessor);
 
-        $services = new ServiceManager(['abstract_factories' => [LoggerAbstractServiceFactory::class]]);
-        $services->setService('LogProcessorManager', $processors);
-        $services->setService('Config', [
-            'log' => [
-                'Application\Frontend' => [
-                    'writers'    => [['name' => Noop::class]],
-                    'processors' => [['name' => 'CustomProcessor']],
+        $config = new Config([
+            'abstract_factories' => [LoggerAbstractServiceFactory::class],
+            'services' => [
+                'LogProcessorManager' => $processors,
+                'config' => [
+                    'log' => [
+                        'Application\Frontend' => [
+                            'writers'    => [['name' => Noop::class]],
+                            'processors' => [['name' => 'CustomProcessor']],
+                        ],
+                    ],
                 ],
             ],
         ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
 
         $log = $services->get('Application\Frontend');
         $logProcessors = $log->getProcessors();

--- a/test/LoggerTest.php
+++ b/test/LoggerTest.php
@@ -157,11 +157,18 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      */
     public function provideTestFilters()
     {
-        return [
+        $data = [
             ['priority', ['priority' => Logger::INFO]],
             ['regex', [ 'regex' => '/[0-9]+/' ]],
-            ['validator', ['validator' => new DigitsFilter]],
         ];
+
+        // Conditionally enabled until zend-validator is forwards-compatible
+        // with zend-servicemanager v3.
+        if (class_exists(DigitsFilter::class)) {
+            $data[] = ['validator', ['validator' => new DigitsFilter]];
+        }
+
+        return $data;
     }
 
     /**

--- a/test/ProcessorPluginManagerCompatibilityTest.php
+++ b/test/ProcessorPluginManagerCompatibilityTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Log;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionProperty;
 use Zend\Log\Exception\InvalidArgumentException;
 use Zend\Log\Processor;
 use Zend\Log\ProcessorPluginManager;

--- a/test/ProcessorPluginManagerCompatibilityTest.php
+++ b/test/ProcessorPluginManagerCompatibilityTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Log\Exception\InvalidArgumentException;
+use Zend\Log\Processor;
+use Zend\Log\ProcessorPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ProcessorPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ProcessorPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Processor\ProcessorInterface::class;
+    }
+}

--- a/test/Writer/DbTest.php
+++ b/test/Writer/DbTest.php
@@ -22,6 +22,13 @@ class DbTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'zend-db related tests are disabled when testing zend-servicemanager v3 '
+                . 'forwards compatibility, until zend-db is also forwards compatible'
+            );
+        }
+
         $this->tableName = 'db-table-name';
 
         $this->db     = new MockDbAdapter();
@@ -329,7 +336,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
                 'file'  => 'new-file',
                 'line'  => 'new-line',
                 'trace' => 'new-trace',
-        ]];
+            ]
+        ];
 
         $method = new ReflectionMethod($this->writer, 'mapEventIntoColumn');
         $method->setAccessible(true);

--- a/test/Writer/MailTest.php
+++ b/test/Writer/MailTest.php
@@ -31,6 +31,13 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (! class_exists(MailMessage::class)) {
+            $this->markTestSkipped(
+                'zend-mail related tests are disabled when testing zend-servicemanager v3 '
+                . 'forwards compatibility, until zend-mail is also forwards compatible'
+            );
+        }
+
         $message = new MailMessage();
         $transport = new Transport\File();
         $options   = new Transport\FileOptions([

--- a/test/WriterPluginManagerCompatibilityTest.php
+++ b/test/WriterPluginManagerCompatibilityTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Log\Exception\InvalidArgumentException;
+use Zend\Log\Writer;
+use Zend\Log\WriterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class WriterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new WriterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Writer\WriterInterface::class;
+    }
+
+    /**
+     * Overrides CommonPluginManagerTrait::aliasProvider
+     *
+     * Iterates through aliases, and for adapters that require extensions,
+     * tests if the extension is loaded, skipping that alias if not.
+     *
+     * @return \Traversable
+     */
+    public function aliasProvider()
+    {
+        $pluginManager = $this->getPluginManager();
+        $r = new ReflectionProperty($pluginManager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($pluginManager);
+
+        foreach ($aliases as $alias => $target) {
+            switch ($target) {
+                case Writer\Mail::class:
+                    // intentionally fall-through
+                case Writer\Db::class:
+                    // intentionally fall-through
+                case Writer\FingersCrossed::class:
+                    // intentionally fall-through
+                case Writer\Mongo::class:
+                    // intentionally fall-through
+                case Writer\Stream::class:
+                    // always skip; these implementations have required arguments
+                    break;
+                default:
+                    yield $alias => [$alias, $target];
+            }
+        }
+    }
+}

--- a/test/WriterPluginManagerTest.php
+++ b/test/WriterPluginManagerTest.php
@@ -28,13 +28,6 @@ class WriterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->plugins = new WriterPluginManager(new ServiceManager());
     }
 
-    public function testRegisteringInvalidWriterRaisesException()
-    {
-        $this->setExpectedException(InvalidServiceException::class);
-        $this->plugins->setService('test', $this);
-        $this->plugins->get('test');
-    }
-
     public function testInvokableClassFirephp()
     {
         $firephp = $this->plugins->get('firephp');

--- a/test/WriterPluginManagerTest.php
+++ b/test/WriterPluginManagerTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Log;
 
 use Zend\Log\WriterPluginManager;
-use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceManager;
 
 /**


### PR DESCRIPTION
- `composer.json` changes:
  - Use PHP `^5.5 || ^7.0`.
  - Updated branch alias; develop becomes 2.7.
  - Updated zend-servicemanager requirement to `^2.7.5 || ^3.0.3`.
  - Removed zend-mvc from `require-dev`; unused, and caused conflicts.
- `.travis.yml` was updated to provide test runs against both 2.7 and 3.0.
- code changes:
  - updated factories to work against both v2 and v3.
  - updated abstract factories to work against both v2 and v3.
  - updated plugin managers to work against both v2 and v3.
  - fixed test assumptions to work against both v2 and v3.
  - made several tests conditional on presence of certain classes; this allows us to test compatibility without worrying about component dependencies that are not yet forwards compatible with zend-servicemanager v3; in each case, a corresponding entry in `.travis.yml` also removes the given development dependency when testing v3 compatibility.
  - added plugin manager compatibility tests to verify forwards compatibility.
