### PR TITLE
Allow multiple instances of all plugin types

### DIFF
--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -43,6 +43,18 @@ class FilterPluginManager extends AbstractPluginManager
     protected $instanceOf = Filter\FilterInterface::class;
 
     /**
+     * Allow many filters of the same type (v2)
+     * @param bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Allow many filters of the same type (v3)
+     * @param bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
      * Validate the plugin is of the expected type (v3).
      *
      * Validates against `$instanceOf`.

--- a/src/FormatterPluginManager.php
+++ b/src/FormatterPluginManager.php
@@ -45,6 +45,18 @@ class FormatterPluginManager extends AbstractPluginManager
     protected $instanceOf = Formatter\FormatterInterface::class;
 
     /**
+     * Allow many formatters of the same type (v2)
+     * @param bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Allow many formatters of the same type (v3)
+     * @param bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
      * Validate the plugin is of the expected type (v3).
      *
      * Validates against `$instanceOf`.

--- a/src/ProcessorPluginManager.php
+++ b/src/ProcessorPluginManager.php
@@ -42,6 +42,18 @@ class ProcessorPluginManager extends AbstractPluginManager
     protected $instanceOf = Processor\ProcessorInterface::class;
 
     /**
+     * Allow many processors of the same type (v2)
+     * @param bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Allow many processors of the same type (v3)
+     * @param bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
      * Validate the plugin is of the expected type (v3).
      *
      * Validates against `$instanceOf`.

--- a/src/WriterPluginManager.php
+++ b/src/WriterPluginManager.php
@@ -70,6 +70,18 @@ class WriterPluginManager extends AbstractPluginManager
     protected $instanceOf = Writer\WriterInterface::class;
 
     /**
+     * Allow many writers of the same type (v2)
+     * @param bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Allow many writers of the same type (v3)
+     * @param bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
      * Validate the plugin is of the expected type (v3).
      *
      * Validates against `$instanceOf`.

--- a/test/FilterPluginManagerCompatibilityTest.php
+++ b/test/FilterPluginManagerCompatibilityTest.php
@@ -20,6 +20,7 @@ use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 class FilterPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
+    use ServicesNotSharedByDefaultTrait;
 
     protected function getPluginManager()
     {

--- a/test/FormatterPluginManagerCompatibilityTest.php
+++ b/test/FormatterPluginManagerCompatibilityTest.php
@@ -19,6 +19,7 @@ use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 class FormatterPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
+    use ServicesNotSharedByDefaultTrait;
 
     protected function getPluginManager()
     {

--- a/test/ProcessorPluginManagerCompatibilityTest.php
+++ b/test/ProcessorPluginManagerCompatibilityTest.php
@@ -19,6 +19,7 @@ use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 class ProcessorPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
+    use ServicesNotSharedByDefaultTrait;
 
     protected function getPluginManager()
     {

--- a/test/ServicesNotSharedByDefaultTrait.php
+++ b/test/ServicesNotSharedByDefaultTrait.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use ReflectionProperty;
+
+trait ServicesNotSharedByDefaultTrait
+{
+    public function testServicesShouldNotBeSharedByDefault()
+    {
+        $plugins = $this->getPluginManager();
+
+        $r = method_exists($plugins, 'configure')
+            ? new ReflectionProperty($plugins, 'sharedByDefault')
+            : new ReflectionProperty($plugins, 'shareByDefault');
+        $r->setAccessible(true);
+        $this->assertFalse($r->getValue($plugins));
+    }
+}

--- a/test/WriterPluginManagerCompatibilityTest.php
+++ b/test/WriterPluginManagerCompatibilityTest.php
@@ -20,6 +20,7 @@ use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 class WriterPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
+    use ServicesNotSharedByDefaultTrait;
 
     protected function getPluginManager()
     {


### PR DESCRIPTION
As reported in #27, 2.7.0 removed the override value for the "share by default" flag in all plugin managers, which breaks backwards compatibility. Previously, each set the flag to boolean `false`, allowing multiple instances.

This patch adds a test trait that checks for the status of the flag (using the correct property based on zend-servicemanager release), and composes it into the plugin manager compatibility tests.
