### PR TITLE
Re-enable mail, db, validator tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-db zendframework/zend-mail zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require-dev": {
         "zendframework/zend-console": "^2.6",
-        "zendframework/zend-db": "^2.5",
+        "zendframework/zend-db": "^2.6",
         "zendframework/zend-escaper": "^2.5",
         "zendframework/zend-filter": "^2.5",
-        "zendframework/zend-mail": "^2.5",
-        "zendframework/zend-validator": "^2.5",
+        "zendframework/zend-mail": "^2.6.1",
+        "zendframework/zend-validator": "^2.6",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0",
         "mikey179/vfsStream": "^1.6"

--- a/test/Filter/ValidatorTest.php
+++ b/test/Filter/ValidatorTest.php
@@ -19,16 +19,6 @@ use Zend\Validator\NotEmpty as NotEmptyFilter;
  */
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        if (! class_exists(ValidatorChain::class)) {
-            $this->markTestSkipped(
-                'zend-validator related tests are disabled when testing zend-servicemanager v3 '
-                . 'forwards compatibility, until zend-validator is also forwards compatible'
-            );
-        }
-    }
-
     public function testValidatorFilter()
     {
         $filter = new Validator(new DigitsFilter());

--- a/test/LoggerAbstractServiceFactoryTest.php
+++ b/test/LoggerAbstractServiceFactoryTest.php
@@ -99,13 +99,6 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testRetrievesDatabaseServiceFromServiceManagerWhenEncounteringDbWriter()
     {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'zend-db related tests are disabled when testing zend-servicemanager v3 '
-                . 'forwards compatibility, until zend-db is also forwards compatible'
-            );
-        }
-
         $db = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
             ->disableOriginalConstructor()
             ->getMock();

--- a/test/Writer/DbTest.php
+++ b/test/Writer/DbTest.php
@@ -22,13 +22,6 @@ class DbTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'zend-db related tests are disabled when testing zend-servicemanager v3 '
-                . 'forwards compatibility, until zend-db is also forwards compatible'
-            );
-        }
-
         $this->tableName = 'db-table-name';
 
         $this->db     = new MockDbAdapter();

--- a/test/Writer/MailTest.php
+++ b/test/Writer/MailTest.php
@@ -31,13 +31,6 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (! class_exists(MailMessage::class)) {
-            $this->markTestSkipped(
-                'zend-mail related tests are disabled when testing zend-servicemanager v3 '
-                . 'forwards compatibility, until zend-mail is also forwards compatible'
-            );
-        }
-
         $message = new MailMessage();
         $transport = new Transport\File();
         $options   = new Transport\FileOptions([


### PR DESCRIPTION
Now that each of zend-mail, zend-db, and zend-validator have known stable, forwards compatible versions, we can re-enable tests against them on Travis.
