### PR TITLE
Expose package as a component and a config-provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,10 @@
         "branch-alias": {
             "dev-master": "2.7-dev",
             "dev-develop": "2.8-dev"
+        },
+        "zf": {
+            "component": "Zend\\Log",
+            "config-provider": "Zend\\Log\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+class ConfigProvider
+{
+    /**
+     * Return configuration for this component.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Return dependency mappings for this component.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'abstract_factories' => [
+                LoggerAbstractServiceFactory::class,
+            ],
+            'factories' => [
+                Logger::class         => LoggerServiceFactory::class,
+                'LogFilterManager'    => FilterPluginManagerFactory::class,
+                'LogFormatterManager' => FormatterPluginManagerFactory::class,
+                'LogProcessorManager' => ProcessorPluginManagerFactory::class,
+                'LogWriterManager'    => WriterPluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/FilterPluginManagerFactory.php
+++ b/src/FilterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FilterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FilterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new FilterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FilterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: FilterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/FormatterPluginManagerFactory.php
+++ b/src/FormatterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FormatterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FormatterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new FormatterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FormatterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: FormatterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+class Module
+{
+    /**
+     * Return default zend-log configuration for zend-mvc applications.
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Register specifications for all zend-log plugin managers with the ServiceListener.
+     *
+     * @param \Zend\ModuleManager\ModuleEvent
+     * @return void
+     */
+    public function init($event)
+    {
+        $container = $event->getParam('ServiceManager');
+        $serviceListener = $container->get('ServiceListener');
+
+        $serviceListener->addServiceManager(
+            'LogProcessorManager',
+            'log_processors',
+            'Zend\ModuleManager\Feature\LogProcessorProviderInterface',
+            'getLogProcessorConfig'
+        );
+
+        $serviceListener->addServiceManager(
+            'LogWriterManager',
+            'log_writers',
+            'Zend\ModuleManager\Feature\LogWriterProviderInterface',
+            'getLogWriterConfig'
+        );
+
+        $serviceListener->addServiceManager(
+            'LogFilterManager',
+            'log_filters',
+            'Zend\Log\Filter\LogFilterProviderInterface',
+            'getLogFilterConfig'
+        );
+
+        $serviceListener->addServiceManager(
+            'LogFormatterManager',
+            'log_formatters',
+            'Zend\Log\Filter\LogFormatterProviderInterface',
+            'getLogFormatterConfig'
+        );
+    }
+}

--- a/src/ProcessorPluginManagerFactory.php
+++ b/src/ProcessorPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ProcessorPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ProcessorPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new ProcessorPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ProcessorPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: ProcessorPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/WriterPluginManagerFactory.php
+++ b/src/WriterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class WriterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return WriterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new WriterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return WriterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: WriterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/test/FilterPluginManagerFactoryTest.php
+++ b/test/FilterPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Log\Filter\FilterInterface;
+use Zend\Log\FilterPluginManager;
+use Zend\Log\FilterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FilterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new FilterPluginManagerFactory();
+
+        $filters = $factory($container, FilterPluginManagerFactory::class);
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+
+        if (method_exists($filters, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $filters);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $filters->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $filter = $this->prophesize(FilterInterface::class)->reveal();
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container, FilterPluginManagerFactory::class, [
+            'services' => [
+                'test' => $filter,
+            ],
+        ]);
+        $this->assertSame($filter, $filters->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $filter = $this->prophesize(FilterInterface::class)->reveal();
+
+        $factory = new FilterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $filter,
+            ],
+        ]);
+
+        $filters = $factory->createService($container->reveal());
+        $this->assertSame($filter, $filters->get('test'));
+    }
+}

--- a/test/FormatterPluginManagerFactoryTest.php
+++ b/test/FormatterPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Log\Formatter\FormatterInterface;
+use Zend\Log\FormatterPluginManager;
+use Zend\Log\FormatterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FormatterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new FormatterPluginManagerFactory();
+
+        $formatters = $factory($container, FormatterPluginManagerFactory::class);
+        $this->assertInstanceOf(FormatterPluginManager::class, $formatters);
+
+        if (method_exists($formatters, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $formatters);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $formatters->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $formatter = $this->prophesize(FormatterInterface::class)->reveal();
+
+        $factory = new FormatterPluginManagerFactory();
+        $formatters = $factory($container, FormatterPluginManagerFactory::class, [
+            'services' => [
+                'test' => $formatter,
+            ],
+        ]);
+        $this->assertSame($formatter, $formatters->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $formatter = $this->prophesize(FormatterInterface::class)->reveal();
+
+        $factory = new FormatterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $formatter,
+            ],
+        ]);
+
+        $formatters = $factory->createService($container->reveal());
+        $this->assertSame($formatter, $formatters->get('test'));
+    }
+}

--- a/test/ProcessorPluginManagerFactoryTest.php
+++ b/test/ProcessorPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Log\Processor\ProcessorInterface;
+use Zend\Log\ProcessorPluginManager;
+use Zend\Log\ProcessorPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ProcessorPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new ProcessorPluginManagerFactory();
+
+        $processors = $factory($container, ProcessorPluginManagerFactory::class);
+        $this->assertInstanceOf(ProcessorPluginManager::class, $processors);
+
+        if (method_exists($processors, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $processors);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $processors->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $processor = $this->prophesize(ProcessorInterface::class)->reveal();
+
+        $factory = new ProcessorPluginManagerFactory();
+        $processors = $factory($container, ProcessorPluginManagerFactory::class, [
+            'services' => [
+                'test' => $processor,
+            ],
+        ]);
+        $this->assertSame($processor, $processors->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $processor = $this->prophesize(ProcessorInterface::class)->reveal();
+
+        $factory = new ProcessorPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $processor,
+            ],
+        ]);
+
+        $processors = $factory->createService($container->reveal());
+        $this->assertSame($processor, $processors->get('test'));
+    }
+}

--- a/test/WriterPluginManagerFactoryTest.php
+++ b/test/WriterPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Log\Writer\WriterInterface;
+use Zend\Log\WriterPluginManager;
+use Zend\Log\WriterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class WriterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new WriterPluginManagerFactory();
+
+        $writers = $factory($container, WriterPluginManagerFactory::class);
+        $this->assertInstanceOf(WriterPluginManager::class, $writers);
+
+        if (method_exists($writers, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $writers);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $writers->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $writer = $this->prophesize(WriterInterface::class)->reveal();
+
+        $factory = new WriterPluginManagerFactory();
+        $writers = $factory($container, WriterPluginManagerFactory::class, [
+            'services' => [
+                'test' => $writer,
+            ],
+        ]);
+        $this->assertSame($writer, $writers->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $writer = $this->prophesize(WriterInterface::class)->reveal();
+
+        $factory = new WriterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $writer,
+            ],
+        ]);
+
+        $writers = $factory->createService($container->reveal());
+        $this->assertSame($writer, $writers->get('test'));
+    }
+}


### PR DESCRIPTION
Added:
- `ProcessorPluginManagerFactory` and `WriterPluginManagerFactory` implementations, per their original implementation in zend-mvc.
- `FilterPluginManagerFactory` and `FormatterPluginManagerFactory` implementations, for consistency within the component.
- `ConfigProvider`, which provides basic dependency configuration for each of the plugin managers, a `Logger` instance, and the abstract logger factory.
- `Module`, which provides the above, but also provides specifications to the zend-modulemanager `ServiceListener` for configuring log filters, formatters, processors, and writers.
