### PR TITLE
Add missing provider interfaces

### DIFF
--- a/src/Filter/LogFilterProviderInterface.php
+++ b/src/Filter/LogFilterProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log\Filter;
+
+interface LogFilterProviderInterface
+{
+    /**
+     * Provide plugin manager configuration for log filters.
+     *
+     * @return array
+     */
+    public function getLogFilterConfig();
+}

--- a/src/Formatter/LogFormatterProviderInterface.php
+++ b/src/Formatter/LogFormatterProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-log for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log\Formatter;
+
+interface LogFormatterProviderInterface
+{
+    /**
+     * Provide plugin manager configuration for log formatters.
+     *
+     * @return array
+     */
+    public function getLogFormatterConfig();
+}


### PR DESCRIPTION
2.8.0 adds `ServiceListener` specifications for filters and formatters, but omits the provider interfaces. This patch adds them.
