### PR TITLE
Composer psr/log-implementation provide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "phpunit/PHPUnit": "~4.0",
         "mikey179/vfsStream": "^1.6"
     },
+    "provide": {
+        "psr/log-implementation": "1.0.0"
+    },
     "suggest": {
         "ext-mongo": "mongodb extension to use MongoDB writer",
         "zendframework/zend-console": "Zend\\Console component to use the RequestID log processor",


### PR DESCRIPTION
zend-log uses an adapter to implement PSR 3 log, but it provides and implementation.
So I added in the `composer.json` the key `provide` for `psr/log-implementation`.
