### PR TITLE
issue #55 fix class name BC break of FormatterPluginManager and Filte…

### DIFF
--- a/src/Writer/AbstractWriter.php
+++ b/src/Writer/AbstractWriter.php
@@ -12,9 +12,9 @@ namespace Zend\Log\Writer;
 use Traversable;
 use Zend\Log\Exception;
 use Zend\Log\Filter;
-use Zend\Log\FilterPluginManager;
+use Zend\Log\FilterPluginManager as NewFilterPluginManager; // @todo Temporary alias until \Zend\Log\Writer\FilterPluginManager has been removed.
 use Zend\Log\Formatter;
-use Zend\Log\FormatterPluginManager;
+use Zend\Log\FormatterPluginManager as NewFormatterPluginManager; // @todo Temporary alias until \Zend\Log\Writer\FilterPluginManager has been removed.
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ErrorHandler;
 
@@ -159,7 +159,7 @@ abstract class AbstractWriter implements WriterInterface
     public function getFilterPluginManager()
     {
         if (null === $this->filterPlugins) {
-            $this->setFilterPluginManager(new FilterPluginManager(new ServiceManager()));
+            $this->setFilterPluginManager(new NewFilterPluginManager(new ServiceManager()));
         }
         return $this->filterPlugins;
     }
@@ -176,10 +176,10 @@ abstract class AbstractWriter implements WriterInterface
         if (is_string($plugins)) {
             $plugins = new $plugins;
         }
-        if (!$plugins instanceof FilterPluginManager) {
+        if (!$plugins instanceof NewFilterPluginManager) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Writer plugin manager must extend %s\FilterPluginManager; received %s',
-                __NAMESPACE__,
+                'Writer plugin manager must extend %s; received %s',
+                NewFilterPluginManager::class,
                 is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
@@ -208,7 +208,7 @@ abstract class AbstractWriter implements WriterInterface
     public function getFormatterPluginManager()
     {
         if (null === $this->formatterPlugins) {
-            $this->setFormatterPluginManager(new FormatterPluginManager(new ServiceManager()));
+            $this->setFormatterPluginManager(new NewFormatterPluginManager(new ServiceManager()));
         }
         return $this->formatterPlugins;
     }
@@ -225,11 +225,11 @@ abstract class AbstractWriter implements WriterInterface
         if (is_string($plugins)) {
             $plugins = new $plugins;
         }
-        if (!$plugins instanceof FormatterPluginManager) {
+        if (!$plugins instanceof NewFormatterPluginManager) {
             throw new Exception\InvalidArgumentException(
                 sprintf(
-                    'Writer plugin manager must extend %s\FormatterPluginManager; received %s',
-                    __NAMESPACE__,
+                    'Writer plugin manager must extend %s; received %s',
+                    NewFormatterPluginManager::class,
                     is_object($plugins) ? get_class($plugins) : gettype($plugins)
                 )
             );

--- a/test/Writer/AbstractTest.php
+++ b/test/Writer/AbstractTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Log\Writer;
 use ReflectionObject;
 use Zend\Log\FilterPluginManager;
 use Zend\Log\FormatterPluginManager;
+use Zend\Log\Writer\FilterPluginManager as LegacyFilterPluginManager;
+use Zend\Log\Writer\FormatterPluginManager as LegacyFormatterPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\Log\TestAsset\ConcreteWriter;
 use ZendTest\Log\TestAsset\ErrorGeneratingWriter;
@@ -147,7 +149,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Log\Writer\AbstractWriter::__construct
      * @expectedException Zend\Log\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Writer plugin manager must extend Zend\Log\Writer\FormatterPluginManager; received integer
+     * @expectedExceptionMessage Writer plugin manager must extend Zend\Log\FormatterPluginManager; received integer
      */
     public function testConstructorWithInvalidFormatterManager()
     {
@@ -161,6 +163,23 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         // No assert needed, expecting an exception.
+    }
+
+    /**
+     * @covers Zend\Log\Writer\AbstractWriter::__construct
+     */
+    public function testConstructorWithLegacyFormatterManager()
+    {
+        // Arrange
+        $pluginManager = new LegacyFormatterPluginManager(new ServiceManager());
+
+        // Act
+        $writer = new ConcreteWriter([
+            'formatter_manager' => $pluginManager,
+        ]);
+
+        // Assert
+        $this->assertSame($pluginManager, $writer->getFormatterPluginManager());
     }
 
     /**
@@ -183,7 +202,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Log\Writer\AbstractWriter::__construct
      * @expectedException Zend\Log\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Writer plugin manager must extend Zend\Log\Writer\FilterPluginManager; received integer
+     * @expectedExceptionMessage Writer plugin manager must extend Zend\Log\FilterPluginManager; received integer
      */
     public function testConstructorWithInvalidFilterManager()
     {
@@ -197,6 +216,23 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         // Nothing to assert, expecting an exception.
+    }
+
+    /**
+     * @covers Zend\Log\Writer\AbstractWriter::__construct
+     */
+    public function testConstructorWithLegacyFilterManager()
+    {
+        // Arrange
+        $pluginManager = new LegacyFilterPluginManager(new ServiceManager());
+
+        // Act
+        $writer = new ConcreteWriter([
+            'filter_manager' => $pluginManager,
+        ]);
+
+        // Assert
+        $this->assertSame($pluginManager, $writer->getFilterPluginManager());
     }
 
     /**


### PR DESCRIPTION
Fixes the following error:

Cannot use Zend\Log\FilterPluginManager as FilterPluginManager because the name is already in use in ./vendor/zendframework/zend-log/src/Writer/AbstractWriter.php on line 15
