### PR TITLE
Simplify RequestId Processor, Remove zend-console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "zendframework/zend-console": "^2.6",
         "zendframework/zend-db": "^2.6",
         "zendframework/zend-escaper": "^2.5",
         "zendframework/zend-filter": "^2.5",

--- a/src/Processor/RequestId.php
+++ b/src/Processor/RequestId.php
@@ -9,8 +9,6 @@
 
 namespace Zend\Log\Processor;
 
-use Zend\Console\Console;
-
 class RequestId implements ProcessorInterface
 {
     /**
@@ -53,19 +51,16 @@ class RequestId implements ProcessorInterface
             return $this->identifier;
         }
 
-        $requestTime = $_SERVER['REQUEST_TIME_FLOAT'];
-
-        if (Console::isConsole()) {
-            $this->identifier = md5($requestTime);
-            return $this->identifier;
-        }
+        $identifier = (string) $_SERVER['REQUEST_TIME_FLOAT'];
 
         if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            $this->identifier = md5($requestTime . $_SERVER['HTTP_X_FORWARDED_FOR']);
-            return $this->identifier;
+            $identifier .= $_SERVER['HTTP_X_FORWARDED_FOR'];
+        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
+            $identifier .= $_SERVER['REMOTE_ADDR'];
         }
 
-        $this->identifier = md5($requestTime . $_SERVER['REMOTE_ADDR']);
+        $this->identifier = md5($identifier);
+
         return $this->identifier;
     }
 }


### PR DESCRIPTION
Zend-Log had a "dev-dependency" to zend-console, which was just used for the Request-ID-Processor.
I refactored the code a little bit and now zend-console is not needed anymore at all. The generated identifier should be the same as before.
