### PR TITLE
Make sure escape value before appendChild() for XML formatter

### DIFF
--- a/src/Formatter/Xml.php
+++ b/src/Formatter/Xml.php
@@ -233,9 +233,9 @@ class Xml implements FormatterInterface
                 $value = $this->getEscaper()->escapeHtml(
                     '"Object" of type ' . get_class($value) . " does not support __toString() method"
                 );
+            } else {
+                $value = $this->getEscaper()->escapeHtml($value);
             }
-
-            $value = $this->getEscaper()->escapeHtml($value);
 
             if (is_numeric($key)) {
                 // xml does not allow numeric values, try to switch the value and the key

--- a/src/Formatter/Xml.php
+++ b/src/Formatter/Xml.php
@@ -235,6 +235,8 @@ class Xml implements FormatterInterface
                 );
             }
 
+            $value = $this->getEscaper()->escapeHtml($value);
+
             if (is_numeric($key)) {
                 // xml does not allow numeric values, try to switch the value and the key
                 $key   = (string) $value;

--- a/test/Formatter/XmlTest.php
+++ b/test/Formatter/XmlTest.php
@@ -252,4 +252,42 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $expected .= "\n" . PHP_EOL;
         $this->assertEquals($expected, $formatter->format($event));
     }
+
+    public function testFormatWillEscapeAmpersand()
+    {
+        $formatter = new XmlFormatter;
+
+        $d = new DateTime('2001-01-01T12:00:00-06:00');
+
+        $event = [
+            'timestamp'    => $d,
+            'message'      => 'test',
+            'priority'     => 1,
+            'priorityName' => 'CRIT',
+            'extra'        => [
+                'test'  => [
+                    'one',
+                    'two' => [
+                        'three' => [
+                            'four' => 'four&four'
+                        ],
+                        'five'  => ['']
+                    ]
+                ],
+                '1111'                => '2222',
+                'test_null'           => null,
+                'test_int'            => 14,
+                'test_object'         => new \stdClass(),
+                new SerializableObject(),
+                'serializable_object' => new SerializableObject(),
+                null,
+                'test_empty_array'    => [],
+                'bar'                 => 'foo',
+                'foobar'
+            ]
+        ];
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four&amp;four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>&amp;quot;Object&amp;quot; of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
+        $expected .= "\n" . PHP_EOL;
+        $this->assertEquals($expected, $formatter->format($event));
+    }
 }

--- a/test/Formatter/XmlTest.php
+++ b/test/Formatter/XmlTest.php
@@ -248,7 +248,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
                 'foobar'
             ]
         ];
-        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>&amp;quot;Object&amp;quot; of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>"Object" of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
         $expected .= "\n" . PHP_EOL;
         $this->assertEquals($expected, $formatter->format($event));
     }
@@ -286,7 +286,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
                 'foobar'
             ]
         ];
-        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four&amp;four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>&amp;quot;Object&amp;quot; of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four&amp;four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>"Object" of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
         $expected .= "\n" . PHP_EOL;
         $this->assertEquals($expected, $formatter->format($event));
     }

--- a/test/Formatter/XmlTest.php
+++ b/test/Formatter/XmlTest.php
@@ -248,7 +248,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
                 'foobar'
             ]
         ];
-        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>"Object" of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>&amp;quot;Object&amp;quot; of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
         $expected .= "\n" . PHP_EOL;
         $this->assertEquals($expected, $formatter->format($event));
     }


### PR DESCRIPTION
to avoid error: " DOMElement::__construct(): unterminated entity reference"