### PR TITLE
Ensure plugin manager config is honored in non-zend-mvc contexts

### DIFF
--- a/src/FilterPluginManagerFactory.php
+++ b/src/FilterPluginManagerFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -29,7 +30,30 @@ class FilterPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new FilterPluginManager($container, $options ?: []);
+        $pluginManager = new FilterPluginManager($container, $options ?: []);
+
+        // If this is in a zend-mvc application, the ServiceListener will inject
+        // merged configuration during bootstrap.
+        if ($container->has('ServiceListener')) {
+            return $pluginManager;
+        }
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config');
+
+        // If we do not have log_filters configuration, nothing more to do
+        if (! isset($config['log_filters']) || ! is_array($config['log_filters'])) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for log_filters
+        (new Config($config['log_filters']))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**

--- a/src/WriterPluginManagerFactory.php
+++ b/src/WriterPluginManagerFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Log;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -29,7 +30,30 @@ class WriterPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new WriterPluginManager($container, $options ?: []);
+        $pluginManager = new WriterPluginManager($container, $options ?: []);
+
+        // If this is in a zend-mvc application, the ServiceListener will inject
+        // merged configuration during bootstrap.
+        if ($container->has('ServiceListener')) {
+            return $pluginManager;
+        }
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config');
+
+        // If we do not have log_writers configuration, nothing more to do
+        if (! isset($config['log_writers']) || ! is_array($config['log_writers'])) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for log_writers
+        (new Config($config['log_writers']))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**

--- a/test/FilterPluginManagerFactoryTest.php
+++ b/test/FilterPluginManagerFactoryTest.php
@@ -70,4 +70,99 @@ class FilterPluginManagerFactoryTest extends TestCase
         $filters = $factory->createService($container->reveal());
         $this->assertSame($filter, $filters->get('test'));
     }
+
+    public function testConfiguresFilterServicesWhenFound()
+    {
+        $filter = $this->prophesize(FilterInterface::class)->reveal();
+        $config = [
+            'log_filters' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($filter) {
+                        return $filter;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container->reveal(), 'FilterManager');
+
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+        $this->assertTrue($filters->has('test'));
+        $this->assertSame($filter, $filters->get('test'));
+        $this->assertTrue($filters->has('test-too'));
+        $this->assertSame($filter, $filters->get('test-too'));
+    }
+
+    public function testDoesNotConfigureFilterServicesWhenServiceListenerPresent()
+    {
+        $filter = $this->prophesize(FilterInterface::class)->reveal();
+        $config = [
+            'log_filters' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($filter) {
+                        return $filter;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(true);
+        $container->has('config')->shouldNotBeCalled();
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container->reveal(), 'FilterManager');
+
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+        $this->assertFalse($filters->has('test'));
+        $this->assertFalse($filters->has('test-too'));
+    }
+
+    public function testDoesNotConfigureFilterServicesWhenConfigServiceNotPresent()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container->reveal(), 'FilterManager');
+
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+    }
+
+    public function testDoesNotConfigureFilterServicesWhenConfigServiceDoesNotContainFiltersConfig()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container->reveal(), 'FilterManager');
+
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+        $this->assertFalse($filters->has('foo'));
+    }
 }

--- a/test/FormatterPluginManagerFactoryTest.php
+++ b/test/FormatterPluginManagerFactoryTest.php
@@ -70,4 +70,99 @@ class FormatterPluginManagerFactoryTest extends TestCase
         $formatters = $factory->createService($container->reveal());
         $this->assertSame($formatter, $formatters->get('test'));
     }
+
+    public function testConfiguresFormatterServicesWhenFound()
+    {
+        $formatter = $this->prophesize(FormatterInterface::class)->reveal();
+        $config = [
+            'log_formatters' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($formatter) {
+                        return $formatter;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new FormatterPluginManagerFactory();
+        $formatters = $factory($container->reveal(), 'FormatterManager');
+
+        $this->assertInstanceOf(FormatterPluginManager::class, $formatters);
+        $this->assertTrue($formatters->has('test'));
+        $this->assertSame($formatter, $formatters->get('test'));
+        $this->assertTrue($formatters->has('test-too'));
+        $this->assertSame($formatter, $formatters->get('test-too'));
+    }
+
+    public function testDoesNotConfigureFormatterServicesWhenServiceListenerPresent()
+    {
+        $formatter = $this->prophesize(FormatterInterface::class)->reveal();
+        $config = [
+            'log_formatters' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($formatter) {
+                        return $formatter;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(true);
+        $container->has('config')->shouldNotBeCalled();
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FormatterPluginManagerFactory();
+        $formatters = $factory($container->reveal(), 'FormatterManager');
+
+        $this->assertInstanceOf(FormatterPluginManager::class, $formatters);
+        $this->assertFalse($formatters->has('test'));
+        $this->assertFalse($formatters->has('test-too'));
+    }
+
+    public function testDoesNotConfigureFormatterServicesWhenConfigServiceNotPresent()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FormatterPluginManagerFactory();
+        $formatters = $factory($container->reveal(), 'FormatterManager');
+
+        $this->assertInstanceOf(FormatterPluginManager::class, $formatters);
+    }
+
+    public function testDoesNotConfigureFormatterServicesWhenConfigServiceDoesNotContainFormattersConfig()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+
+        $factory = new FormatterPluginManagerFactory();
+        $formatters = $factory($container->reveal(), 'FormatterManager');
+
+        $this->assertInstanceOf(FormatterPluginManager::class, $formatters);
+        $this->assertFalse($formatters->has('foo'));
+    }
 }

--- a/test/WriterPluginManagerFactoryTest.php
+++ b/test/WriterPluginManagerFactoryTest.php
@@ -70,4 +70,99 @@ class WriterPluginManagerFactoryTest extends TestCase
         $writers = $factory->createService($container->reveal());
         $this->assertSame($writer, $writers->get('test'));
     }
+
+    public function testConfiguresWriterServicesWhenFound()
+    {
+        $writer = $this->prophesize(WriterInterface::class)->reveal();
+        $config = [
+            'log_writers' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($writer) {
+                        return $writer;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new WriterPluginManagerFactory();
+        $writers = $factory($container->reveal(), 'WriterManager');
+
+        $this->assertInstanceOf(WriterPluginManager::class, $writers);
+        $this->assertTrue($writers->has('test'));
+        $this->assertSame($writer, $writers->get('test'));
+        $this->assertTrue($writers->has('test-too'));
+        $this->assertSame($writer, $writers->get('test-too'));
+    }
+
+    public function testDoesNotConfigureWriterServicesWhenServiceListenerPresent()
+    {
+        $writer = $this->prophesize(WriterInterface::class)->reveal();
+        $config = [
+            'log_writers' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($writer) {
+                        return $writer;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(true);
+        $container->has('config')->shouldNotBeCalled();
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new WriterPluginManagerFactory();
+        $writers = $factory($container->reveal(), 'WriterManager');
+
+        $this->assertInstanceOf(WriterPluginManager::class, $writers);
+        $this->assertFalse($writers->has('test'));
+        $this->assertFalse($writers->has('test-too'));
+    }
+
+    public function testDoesNotConfigureWriterServicesWhenConfigServiceNotPresent()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new WriterPluginManagerFactory();
+        $writers = $factory($container->reveal(), 'WriterManager');
+
+        $this->assertInstanceOf(WriterPluginManager::class, $writers);
+    }
+
+    public function testDoesNotConfigureWriterServicesWhenConfigServiceDoesNotContainWritersConfig()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+
+        $factory = new WriterPluginManagerFactory();
+        $writers = $factory($container->reveal(), 'WriterManager');
+
+        $this->assertInstanceOf(WriterPluginManager::class, $writers);
+        $this->assertFalse($writers->has('foo'));
+    }
 }


### PR DESCRIPTION
Per https://discourse.zendframework.com/t/validatormanager-not-calling-custom-validator-factory/109/5?u=matthew the `log_processors`, `log_writers`, `log_filters`, and `log_formatters` config keys are not honored currently unless the application is within a zend-mvc context. This is due to the fact that `Zend\Log\Module` wires configuration for the `Zend\ModuleManager\Listener\ServiceListener` in order to push merged service configuration into the plugin during bootstrap; no similar logic is available when not in a zend-mvc context, however.

This patch fixes that situation by modifying each of the `ProcessorPluginManagerFactory`, `WriterPluginManagerFactory`, `FilterPluginManagerFactory`, and `FormatterPluginManagerFactory` to do the following:

- If a `ServiceListener` service exists, it returns the plugin manager immediately (old behavior).
- Otherwise, it checks for the `config` service, and, if found, the relevant key (`log_processors`, `log_writers`, `log_filters`, or `log_formatters`) with an array value. When found, it feeds that value to a `Zend\ServiceManager\Config` instance and uses that to configure the plugin manager before returning it.