### PR TITLE
Fixed example with priority in service manager.

### DIFF
--- a/doc/book/service-manager.md
+++ b/doc/book/service-manager.md
@@ -50,7 +50,11 @@ return [
                     'options' => [
                         'stream' => 'php://output',
                         'formatter' => [
-                            'name' => 'MyFormatter',
+                            'name' => \Zend\Log\Formatter\Simple::class,
+                            'options' => [
+                                'format' => '%timestamp% %priorityName% (%priority%): %message% %extra%',
+                                'dateTimeFormat' => 'c',
+                            ],
                         ],
                         'filters' => [
                             'priority' => [
@@ -93,6 +97,29 @@ The second priority is a filter, the severity in fact. It means that the writer
 will be enabled only when the filter is lower or equal (by default) to the
 priority (the biggest severity is 0).
 
+For the formatter and the filters, only the `name` is required, the options have
+default values (the values set in this example are the default ones). When only
+the name is needed, a shorter format can be used:
+
+```php
+// module.config.php
+                    'options' => [
+                        'stream' => 'php://output',
+                        'formatter' => \Zend\Log\Formatter\Simple::class,
+                        'filters' => [
+                            'priority' => \Zend\Log\Filter\Priority::class,
+                        ],
+                    ],
+];
+```
+
+Because the main filter is `Priority`, it can be set directly too:
+
+```php
+// module.config.php
+                        'filters' => \Zend\Log\Logger::INFO,
+];
+```
 
 ## Custom Writers, Formatters, Filters, and Processors
 

--- a/doc/book/service-manager.md
+++ b/doc/book/service-manager.md
@@ -46,7 +46,7 @@ return [
             'writers' => [
                 'stream' => [
                     'name' => 'stream',
-                    'priority' => 1,
+                    'priority' => \Zend\Log\Logger::ALERT,
                     'options' => [
                         'stream' => 'php://output',
                         'formatter' => [
@@ -82,19 +82,16 @@ the configuration (`MyLogger`):
 $logger = $container->get('MyLogger');
 ```
 
-Notes:
-
-- The keys of the writers are not required, but they make the merge of the
-config files easier. The same remark can be made for the list of processors,
-filters, etc.
-
-- The key `priority` next to the key `name` should not be mingled with the
+The key `priority` next to the key `name` should not be mingled with the
 priority of the writer. The first is the priority in the queue, i.e. the writer
-among all the writers here. It can be any integer, and the default is `1`.
-Bigger the number, bigger is the priority. A writer with a lower priority will
-be triggered later. The second priority is a filter, the severity in fact. It
-means that the writer will be enabled only when the filter is lower or equal (by
-default) to the priority (the biggest severity is 0).
+among all the writers here. It can be any integer, and the default is `1`
+(`\Zend\Log\Logger::ALERT`) for the writers. Bigger the number, bigger is the
+priority. A writer with a lower priority will be triggered later, so `ALERT` is
+triggered after `DEBUG`. For details on the list of the priorities, see
+[Using Built-in Priorities](https://docs.zendframework.com/zend-log/intro/#using-built-in-priorities).
+The second priority is a filter, the severity in fact. It means that the writer
+will be enabled only when the filter is lower or equal (by default) to the
+priority (the biggest severity is 0).
 
 
 ## Custom Writers, Formatters, Filters, and Processors

--- a/doc/book/service-manager.md
+++ b/doc/book/service-manager.md
@@ -44,20 +44,29 @@ return [
     'log' => [
         'MyLogger' => [
             'writers' => [
-                [
+                'stream' => [
                     'name' => 'stream',
-                    'priority' => Logger::DEBUG,
+                    'priority' => 1,
                     'options' => [
                         'stream' => 'php://output',
                         'formatter' => [
                             'name' => 'MyFormatter',
                         ],
                         'filters' => [
-                            [
-                                'name' => 'MyFilter',
+                            'priority' => [
+                                'name' => 'priority',
+                                'options' => [
+                                    'operator' => '<=',
+                                    'priority' => \Zend\Log\Logger::INFO,
+                                ],
                             ],
                         ],
                     ],
+                ],
+            ],
+            'processors' => [
+                'requestid' => [
+                    'name' => \Zend\Log\Processor\RequestId::class,
                 ],
             ],
         ],
@@ -72,6 +81,21 @@ the configuration (`MyLogger`):
 /** @var \Zend\Log\Logger $logger */ 
 $logger = $container->get('MyLogger');
 ```
+
+Notes:
+
+- The keys of the writers are not required, but they make the merge of the
+config files easier. The same remark can be made for the list of processors,
+filters, etc.
+
+- The key `priority` next to the key `name` should not be mingled with the
+priority of the writer. The first is the priority in the queue, i.e. the writer
+among all the writers here. It can be any integer, and the default is `1`.
+Bigger the number, bigger is the priority. A writer with a lower priority will
+be triggered later. The second priority is a filter, the severity in fact. It
+means that the writer will be enabled only when the filter is lower or equal (by
+default) to the priority (the biggest severity is 0).
+
 
 ## Custom Writers, Formatters, Filters, and Processors
 

--- a/doc/book/service-manager.md
+++ b/doc/book/service-manager.md
@@ -86,17 +86,6 @@ the configuration (`MyLogger`):
 $logger = $container->get('MyLogger');
 ```
 
-The key `priority` next to the key `name` should not be mingled with the
-priority of the writer. The first is the priority in the queue, i.e. the writer
-among all the writers here. It can be any integer, and the default is `1`
-(`\Zend\Log\Logger::ALERT`) for the writers. Bigger the number, bigger is the
-priority. A writer with a lower priority will be triggered later, so `ALERT` is
-triggered after `DEBUG`. For details on the list of the priorities, see
-[Using Built-in Priorities](https://docs.zendframework.com/zend-log/intro/#using-built-in-priorities).
-The second priority is a filter, the severity in fact. It means that the writer
-will be enabled only when the filter is lower or equal (by default) to the
-priority (the biggest severity is 0).
-
 For the formatter and the filters, only the `name` is required, the options have
 default values (the values set in this example are the default ones). When only
 the name is needed, a shorter format can be used:

--- a/doc/book/writers.md
+++ b/doc/book/writers.md
@@ -534,3 +534,17 @@ which means that:
 - higher integer values indicate higher priority (triggered earliest);
 - lower integer values (including negative values) have lower priority
 (triggered last).
+
+## Distinction between priority in the queue of writers and the filter `Priority`
+
+When you add a writer to the logger, you can set its priority as a second
+argument. This priority is the priority in the queue of all writers of the
+logger. It can be any integer, and the default is `1` (`\Zend\Log\Logger::ALERT`)
+for the writers. Bigger the number, bigger is the priority. A writer with a
+lower priority will  be triggered later, so `ALERT` is triggered after `DEBUG`.
+For  details on the list of the priorities, see [Using Built-in Priorities](https://docs.zendframework.com/zend-log/intro/#using-built-in-priorities).
+
+This priority should not be mingled with the filter [`Priority`](https://docs.zendframework.com/zend-log/filters/#available-filters).
+In fact, this is the severity. It means that the writer will output the message
+only when the filter is lower or equal (by default) to the priority (the biggest
+severity is 0).


### PR DESCRIPTION
The priority in the queue and in the filter are mingled, so this fixes the example and add a remark.