### PR TITLE
Bad WriterInterface implementation

### DIFF
--- a/src/Writer/Mongo.php
+++ b/src/Writer/Mongo.php
@@ -90,9 +90,10 @@ class Mongo extends AbstractWriter
      * This writer does not support formatting.
      *
      * @param string|FormatterInterface $formatter
+     * @param array|null $options (unused)
      * @return WriterInterface
      */
-    public function setFormatter($formatter)
+    public function setFormatter($formatter, array $options = null)
     {
         return $this;
     }


### PR DESCRIPTION
AbstractWritter::setFormatter($formatter, array $options = null) does not conform WriterInterface::setFormatter($formatter).

Changed WriterInterface and all descendat subclasses.

Tests has the same result as master.