### PR TITLE
Do not suggest Zend\Console anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "suggest": {
         "ext-mongo": "mongo extension to use Mongo writer",
         "ext-mongodb": "mongodb extension to use MongoDB writer",
-        "zendframework/zend-console": "Zend\\Console component to use the RequestID log processor",
         "zendframework/zend-db": "Zend\\Db component to use the database log writer",
         "zendframework/zend-escaper": "Zend\\Escaper component, for use in the XML log formatter",
         "zendframework/zend-mail": "Zend\\Mail component to use the email log writer",


### PR DESCRIPTION
In PR https://github.com/zendframework/zend-log/pull/57 the dependecy to `zendframework/zend-log` was removed (by me). 
Today I noticed that `zend-log` is still suggested via composer to use the `RequestId` processor, which after my PR (see above) is not true anymore.