### PR TITLE
Change the priority value to avoid confused with Priority filter

### DIFF
--- a/docs/book/service-manager.md
+++ b/docs/book/service-manager.md
@@ -46,7 +46,7 @@ return [
             'writers' => [
                 'stream' => [
                     'name' => 'stream',
-                    'priority' => \Zend\Log\Logger::ALERT,
+                    'priority' => 1,
                     'options' => [
                         'stream' => 'php://output',
                         'formatter' => [


### PR DESCRIPTION
This priority should not be confused with the Priority filter, which determines if a message meets a severity threshold. When a Priority filter is attached, the writer will output the message only when the filter is lower or equal (by default) to the priority (the biggest severity is 0).
This priority is the priority in the queue of all writers of the logger. It can be any integer, and the default is 1

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
