### PR TITLE
fixes wrong method name for ReferenceId in documentation

### DIFF
--- a/docs/book/processors.md
+++ b/docs/book/processors.md
@@ -111,7 +111,7 @@ Given the following:
 
 ```php
 $processor = new Zend\Log\Processor\ReferenceId();
-$processor->setIdentifier(microtime(true) . '_' . uniqid());
+$processor->setReferenceId(microtime(true) . '_' . uniqid());
 $logger->addProcessor($processor);
 $logger->info('Log event');
 ```


### PR DESCRIPTION
- [x] Is this related to documentation?

Regarding the current methods of the class `Zend\Log\Processor\ReferenceId`, there's no method `setIdentifier` but a method `setReferenceId`.

https://github.com/zendframework/zend-log/blob/master/src/Processor/ReferenceId.php
https://github.com/zendframework/zend-log/blob/master/src/Processor/RequestId.php

